### PR TITLE
Embed (modified) Firefox Profiler to inspect Job profiles

### DIFF
--- a/lib/sidekiq/profiler.rb
+++ b/lib/sidekiq/profiler.rb
@@ -1,0 +1,58 @@
+require "fileutils"
+
+module Sidekiq
+  # Allows the user to profile jobs running in production.
+  # See details in the Profiling wiki page.
+  class Profiler
+    EXPIRY = 12 * 3600 # 12 hours
+    DEFAULT_OPTIONS = {
+      mode: :wall
+    }
+
+    include Sidekiq::Component
+    def initialize(config)
+      @config = config
+    end
+
+    def call(job, &block)
+      return yield unless job["profile"]
+
+      if RUBY_VERSION < "3.3"
+        logger.warn { "Job profiling requires Ruby 3.3, you are using Ruby #{RUBY_VERSION}" }
+        # Should we execute the job or raise an error?
+        # We consider profiling best effort and execute anyways.
+        # Open an issue and explain your POV if you disagree.
+        return yield
+      end
+
+      token = job["profile"]
+      type = job["class"]
+      jid = job["jid"]
+      started_at = Time.now
+      options = DEFAULT_OPTIONS.merge((job["profiler_options"] || {}).transform_keys!(&:to_sym))
+
+      rundata = {
+        started_at: started_at.to_i,
+        token: token,
+        type: type,
+        jid: jid,
+        # .gz extension tells Vernier to compress the data
+        filename: "#{token}-#{type}-#{jid}-#{started_at.strftime("%Y%m%d-%H%M%S")}.json.gz"
+      }
+
+      require "vernier"
+      Vernier.profile(**options.merge(out: rundata[:filename]), &block)
+
+      key = "#{token}-#{jid}"
+      redis do |conn|
+        conn.multi do |m|
+          m.zadd("profiles", Time.now.to_f + EXPIRY, key)
+          m.hset(key, rundata.merge(data: File.read(rundata[:filename])))
+          m.expire(key, EXPIRY)
+        end
+      end
+
+      FileUtils.rm(rundata[:filename])
+    end
+  end
+end

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -36,6 +36,11 @@ module Sidekiq
       "Profiles" => "profiles"
     }
 
+    PROFILE_OPTIONS = {
+      view_url: "https://profiler.firefox.com/public/%s",
+      store_url: "https://api.profiler.firefox.com/compressed-store"
+    }
+
     if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")
       CONTENT_LANGUAGE = "Content-Language"
       CONTENT_SECURITY_POLICY = "Content-Security-Policy"

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -32,7 +32,8 @@ module Sidekiq
       "Retries" => "retries",
       "Scheduled" => "scheduled",
       "Dead" => "morgue",
-      "Metrics" => "metrics"
+      "Metrics" => "metrics",
+      "Profiles" => "profiles"
     }
 
     if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -205,7 +205,7 @@ module Sidekiq
       rules = [[:all, {Rack::CACHE_CONTROL => "private, max-age=86400"}]] unless ENV["SIDEKIQ_WEB_TESTING"]
 
       ::Rack::Builder.new do
-        use Rack::Static, urls: ["/stylesheets", "/images", "/javascripts"],
+        use Rack::Static, urls: ["/stylesheets", "/images", "/javascripts", "/profile-viewer"],
           root: ASSETS,
           cascade: true,
           header_rules: rules

--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -18,6 +18,11 @@ module Sidekiq
       throw :halt, [res, {Rack::CONTENT_TYPE => "text/plain"}, [res.to_s]]
     end
 
+    def redirect_to(url)
+      Sidekiq.logger.info "Redirecting to #{url}"
+      throw :halt, [302, {Web::LOCATION => url}, []]
+    end
+
     def redirect(location)
       throw :halt, [302, {Web::LOCATION => "#{request.base_url}#{location}"}, []]
     end

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "base64"
+
 module Sidekiq
   class WebApplication
     extend WebRouter
@@ -366,7 +368,7 @@ module Sidekiq
           {"Accept" => "application/vnd.firefox-profiler+json;version=1.0",
            "User-Agent" => "Sidekiq #{Sidekiq::VERSION} job profiler"})
         # https://raw.githubusercontent.com/firefox-devtools/profiler-server/master/tools/decode_jwt_payload.py
-        sid = JSON.load(Base64.decode64(resp.body.split(".")[1]))["profileToken"]
+        sid = Sidekiq.load_json(Base64.decode64(resp.body.split(".")[1]))["profileToken"]
         Sidekiq.redis { |c| c.hset(key, "sid", sid) }
       end
       url = Web::PROFILE_OPTIONS[:view_url] % sid

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -328,6 +328,24 @@ module Sidekiq
       json Sidekiq::Stats.new.queues
     end
 
+    get "/profiles" do
+      erb(:profiles)
+    end
+
+    get "/profiles/:key" do
+      # TODO
+    end
+
+    get "/profiles/:key/data" do
+      key = route_params[:key]
+      data = Sidekiq.redis { |c| c.hget(key, "data") }
+
+      [200, {
+        "content-type" => "application/json",
+        "content-encoding" => "gzip"
+      }, [data]]
+    end
+
     ########
     # Filtering
 

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -333,7 +333,22 @@ module Sidekiq
     end
 
     get "/profiles/:key" do
-      # TODO
+      key = route_params[:key]
+      sid = Sidekiq.redis { |c| c.hget(key, "sid") }
+
+      unless sid
+        require "net/http"
+        data = Sidekiq.redis { |c| c.hget(key, "data") }
+        resp = Net::HTTP.post(URI(Web::PROFILE_OPTIONS[:store_url]),
+          data,
+          {"Accept" => "application/vnd.firefox-profiler+json;version=1.0",
+           "User-Agent" => "Sidekiq #{Sidekiq::VERSION} job profiler"})
+        # https://raw.githubusercontent.com/firefox-devtools/profiler-server/master/tools/decode_jwt_payload.py
+        sid = JSON.load(Base64.decode64(resp.body.split(".")[1]))["profileToken"]
+        Sidekiq.redis { |c| c.hset(key, "sid", sid) }
+      end
+      url = Web::PROFILE_OPTIONS[:view_url] % sid
+      redirect_to url
     end
 
     get "/profiles/:key/data" do

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -342,7 +342,9 @@ module Sidekiq
 
       [200, {
         "content-type" => "application/json",
-        "content-encoding" => "gzip"
+        "content-encoding" => "gzip",
+        # allow Firefox Profiler's XHR to fetch this profile data
+        "access-control-allow-origin" => "*"
       }, [data]]
     end
 

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -411,5 +411,17 @@ module Sidekiq
         job.add_to_queue
       end
     end
+
+    # This method assumes Firefox Profiler compiled assets are in
+    # <code>profile-viewer</code> path.
+    #
+    # @return profile_record [ProfileRecord]
+    def firefox_profiler_url(profile_record)
+      [
+        root_path,
+        "profile-viewer/index.html?sidekiq-profile=",
+        CGI.escape_uri_component("#{root_path}profiles/#{CGI.escape(profile_record.key)}/data")
+      ].join("")
+    end
   end
 end

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -18,3 +18,5 @@ gem "json"
 gem "after_commit_everywhere"
 
 gem "sidekiq-redis_info", path: "../examples/webui-ext"
+
+gem "vernier", "~> 1.2"

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -805,6 +805,52 @@ describe "API" do
       assert_equal 0, rs.size
     end
   end
+
+  describe "profiling" do
+    it "can show profile records" do
+      ps = Sidekiq::ProfileSet.new
+      assert_equal 0, ps.size
+
+      before = Time.now
+      add_profile(1, "mike", "123")
+      add_profile(2, "mike", "456")
+      add_profile(3, "fred", "789")
+      assert_equal 0, ps.size
+      ps = Sidekiq::ProfileSet.new
+      assert_equal 3, ps.size
+
+      ps.each do |record|
+        assert_equal "ProfileJob", record.type
+        assert_operator before, :<, record.started_at
+        assert record.token
+        assert record.jid
+      end
+    end
+  end
+end
+
+FAKE_DATA = "H4sICNrWI2cAA3NvbWUuanNvbgCrVlDKTq1UslJQKkvMKU1V0lFQSiwqSgSJRBvqKBjpKBjHKtRyAQDd7Kt/JwAAAA=="
+
+def add_profile(count, token, jid)
+  type = "ProfileJob"
+  started_at = Time.now + count
+  rundata = {
+    started_at: started_at.to_i,
+    token: token,
+    type: type,
+    jid: jid,
+    # .gz extension tells Vernier to compress the data
+    filename: "#{token}-#{type}-#{jid}-#{started_at.strftime("%Y%m%d-%H%M%S")}.json.gz"
+  }
+
+  key = "#{token}-#{jid}"
+  @cfg.redis do |conn|
+    conn.multi do |m|
+      m.zadd("profiles", Time.now.to_f + 60, key)
+      m.hset(key, rundata.merge(data: Base64.decode64(FAKE_DATA)))
+      m.expire(key, 60)
+    end
+  end
 end
 
 def timing(str)

--- a/web/views/profile.erb
+++ b/web/views/profile.erb
@@ -1,0 +1,13 @@
+<p>Firefox profiler is contained by an <code>iframe</code> as to not break
+the browser's history navigation.
+<a target="_blank" href="<%= firefox_profiler_url(@profile) %>">Open in new tab</a>.
+</p>
+
+<section class="profiler-container">
+  <iframe
+    style="width: 100%; min-height: 500px;"
+    id="ff_profiler_frame"
+    src="<%= firefox_profiler_url(@profile) %>"
+  >
+  </iframe>
+</section>

--- a/web/views/profiles.erb
+++ b/web/views/profiles.erb
@@ -1,0 +1,27 @@
+<div class="header-container">
+  <h1><%= t('Profiles') %></h1>
+</div>
+
+<div class="table_container">
+  <table class="table table-hover table-bordered table-striped">
+    <thead>
+      <th><%= t('CreatedAt') %></th>
+      <th><%= t('Type') %></th>
+      <th><%= t('JID') %></th>
+      <th><%= t('Token') %></th>
+      <th>&nbsp</th>
+    </thead>
+    <% Sidekiq::ProfileSet.new.each do |record| %>
+      <tr>
+        <td><%= relative_time(record.started_at) %></td>
+        <td><%= record.type %> </td>
+        <td><%= record.jid %> </td>
+        <td><%= record.token %> </td>
+        <td>
+          <a class="btn" href="<%= root_path %>profiles/<%= CGI.escape(record.key) %>">View</a>
+          <a class="btn" href="<%= root_path %>profiles/<%= CGI.escape(record.key) %>/data">Raw JSON</a>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+</div>


### PR DESCRIPTION
* [x] Embed profiler in rails application
* [ ] Ensure profiler icons load

## Instructions

1. Fork firefox-devtools/profiler
2. Apply the patch from below to the file `src/actions/app.js` on line `103`
```diff
+
+    const currentUrl = new URL(window.location);
+    if (currentUrl.searchParams.has('sidekiq-profile')) {
+      window.setTimeout(function() {
+        dispatch({
+          type: 'TRIGGER_LOADING_FROM_URL',
+          profileUrl: window.decodeURIComponent(currentUrl.searchParams.get('sidekiq-profile'))
+        });
+      })
+    }
```
3. Build assets and copy them to sidekiq:
```
yarn build
rm -rf /path/to/sidekiq/web/assets/profile-viewer/
mv dist /path/to/sidekiq/web/assets/profile-viewer
```
4. Follow instructions from https://github.com/sidekiq/sidekiq/pull/6485

## Screenshots

View of page `/profiles/:key`

![image](https://github.com/user-attachments/assets/0c612f11-1cc2-4129-be21-1bc14208e160)
